### PR TITLE
Issue/78 specific support email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# data-dot-food-editor change history
+
+## 1.0.6 - 2020-10-16 (Bogdan)
+
+- Replaced the FSA support email address with a more specific one
+
+## 1.0.5 - 2020-10-14 (Bogdan)
+
+- Updated all dependencies, this resulted in the removal of a lot of boilerplate
+  config files, as well as some code changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-dot-food-editor",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/Reports.vue
+++ b/src/Reports.vue
@@ -13,7 +13,7 @@ Add new dataset
       <h1>Reports</h1>
       <h3>Published datasets</h3>
       <div class="alert alert-warning text-center">
-        <p>This is an idea of what could be shown on the reports page. Please <a href="mailto:fsa-support@epimorphics.com">send feedback</a> with ideas of what you'd like to see here.</p>
+        <p>This is an idea of what could be shown on the reports page. Please <a href="mailto:data-fguk-fsa-support@epimorphics.com">send feedback</a> with ideas of what you'd like to see here.</p>
       </div>
       <chart :options="pubGraph" ref="pie"></chart>
 

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -7,7 +7,7 @@ Template footer
       <img src="../assets/epimorphics.png" class="epimorphics-logo" alt="Epimorphics">
       <div>
         Data catalog editor by Epimorphics Ltd, linked-data technology <br/>
-        For help and support, please contact <a href="mailto:fsa-support@epimorphics.com">Support</a> <br/>
+        For help and support, please contact <a href="mailto:data-fguk-fsa-support@epimorphics.com">Support</a> <br/>
         &copy; {{ new Date().getFullYear() }}
         <div class="version">{{version}}</div>
       </div>


### PR DESCRIPTION
This PR aims to replace the FSA support email throughout the app with a new specific one, according to https://github.com/FoodStandardsAgency/data-dot-food/issues/78 . In the future the email will also be made available in other areas of the site, such as the help page