### PR TITLE
Issue/16 help page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # data-dot-food-editor change history
 
-## 1.0.7 - 2020-10-16 (Bogdan)
+## 1.1.0 - 2020-10-16 (Bogdan)
 
 - Added a help page and a link to it in the navigation bar. It's currently just
   a draft and future updates to it are required to make it relevant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # data-dot-food-editor change history
 
+## 1.0.7 - 2020-10-16 (Bogdan)
+
+- Added a help page and a link to it in the navigation bar. It's currently just
+  a draft and future updates to it are required to make it relevant
+
 ## 1.0.6 - 2020-10-16 (Bogdan)
 
 - Replaced the FSA support email address with a more specific one

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-dot-food-editor",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-dot-food-editor",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/Help.vue
+++ b/src/Help.vue
@@ -19,6 +19,6 @@ export default {
 
 <style lang="scss" scoped>
 h2 {
-  font-size: 1.5em;;
+  font-size: 1.5em;
 }
 </style>

--- a/src/Help.vue
+++ b/src/Help.vue
@@ -1,0 +1,22 @@
+<template>
+  <main>
+    <div class="container">
+      <h1>Help</h1>
+      <h3>1. About this page</h3>
+      <p>This page is currently a draft and contains temporary content.</p>
+      <p>In the future this will contain information about the website, likely a FAQ section, and a table of contents area.</p>
+    </div>
+  </main>
+</template>
+
+<script>
+export default {
+  data () {
+    return {}
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/src/Help.vue
+++ b/src/Help.vue
@@ -2,7 +2,7 @@
   <main>
     <div class="container">
       <h1>Help</h1>
-      <h3>1. About this page</h3>
+      <h2>1. About this page</h2>
       <p>This page is currently a draft and contains temporary content.</p>
       <p>In the future this will contain information about the website, likely a FAQ section, and a table of contents area.</p>
     </div>
@@ -18,5 +18,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
+h2 {
+  font-size: 1.5em;;
+}
 </style>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -26,6 +26,7 @@ Replace with any site-specific navigation elements and styling
             <li><router-link to="/">Home</router-link></li>
             <li><router-link to="/reports">Reports</router-link></li>
             <li><router-link to="/publish">Publication</router-link></li>
+            <li><router-link to="/help">Help</router-link></li>
           </ul>
           <navigationUser></navigationUser>
         </div><!-- /.navbar-collapse -->

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,7 @@ import Moment from 'vue-moment'
 import Messages from './components/Messages'
 import Reports from './Reports'
 import Publish from './Publish'
+import Help from './Help'
 import Chart from 'vue-echarts'
 import vee8601 from './vee-iso8601'
 import VuejsDialog from 'vuejs-dialog';
@@ -64,6 +65,7 @@ const router = new VueRouter({
     { path: '/login', component: Login, name: 'login' },
     { path: '/reports', component: Reports, name: 'reports' },
     { path: '/publish', component: Publish, name: 'publish' },
+    { path: '/help', component: Help, name: 'help' },
     { path: '/dataset/:id?', component: DatasetDetails, name: 'dataset' },
     { path: '/dataset/:id/elements', component: ElementList, name: 'elements' },
     { path: '/dataset/:id/elements/:eid', component: ElementDetails, name: 'element' }


### PR DESCRIPTION
This PR adds a help page to the app, according to issue https://github.com/FoodStandardsAgency/data-dot-food/issues/16 . It is accessed via the navigation bar and is currently just a draft, awaiting future relevant content