### PR TITLE
Spike/dropdowns fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # data-dot-food-editor change history
 
+## 1.1.1 - 2020-10-20 (Bogdan)
+
+- Added a fix for keywords and activities dropdowns; the bug was caused by
+  updating the dependecies. It should now work as intended
+
 ## 1.0.6 - 2020-10-16 (Bogdan)
 
 - Replaced the FSA support email address with a more specific one

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-dot-food-editor",
-  "version": "1.0.6",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/Dataset-Details.vue
+++ b/src/Dataset-Details.vue
@@ -117,21 +117,23 @@ Allow editing of all attributes
                     </span>
                   </div>
                   <div class="input-group-btn">
-                    <button type="button" class="btn btn-lg btn-success dropdown-toggle keywords-dropdown-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Add <span class="caret"></span></button>
-                    <ul class="dropdown-menu dropdown-menu-right keywords-dropdown">
-                      <li>
-                        <div class="add-tag-form">
-                          <form v-on:submit.prevent="handleAddTag">
-                            <label>New tag</label>
-                            <input v-model="newTagInput" type="text"/>
-                          </form>
-                        </div>
-                      </li>
-                      <li role="separator" class="divider"></li>
-                      <li v-for="keyword in allowedKeywords" :key="keyword['@id']">
-                        <a href="#" v-on:click.prevent="addTagObject(keyword)">{{keyword.prefLabel}}</a>
-                      </li>
-                    </ul>
+                    <div class="dropdown">
+                      <button type="button" class="btn btn-lg btn-success dropdown-toggle keywords-dropdown-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Add <span class="caret"></span></button>
+                      <ul class="dropdown-menu keywords-dropdown">
+                        <li>
+                          <div class="add-tag-form">
+                            <form v-on:submit.prevent="handleAddTag">
+                              <label>New tag</label>
+                              <input v-model="newTagInput" type="text"/>
+                            </form>
+                          </div>
+                        </li>
+                        <li role="separator" class="divider"></li>
+                        <li v-for="keyword in allowedKeywords" :key="keyword['@id']">
+                          <a href="#" v-on:click.prevent="addTagObject(keyword)">{{keyword.prefLabel}}</a>
+                        </li>
+                      </ul>
+                    </div>
                   </div><!-- /btn-group -->
                 </div>
               </div>
@@ -146,14 +148,16 @@ Allow editing of all attributes
                     </span>
                   </div>
                   <div class="input-group-btn">
-                    <button type="button" class="btn btn-lg btn-success dropdown-toggle keywords-dropdown-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                      Add <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu dropdown-menu-right keywords-dropdown">
-                      <li v-for="activity in activities" :key="activity['@id']">
-                        <a href="#" v-on:click.prevent="addActivity(activity)">{{activity.niceName}}</a>
-                      </li>
-                    </ul>
+                    <div class="dropdown">
+                      <button type="button" class="btn btn-lg btn-success dropdown-toggle keywords-dropdown-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        Add <span class="caret"></span>
+                      </button>
+                      <ul class="dropdown-menu keywords-dropdown">
+                        <li v-for="activity in activities" :key="activity['@id']">
+                          <a href="#" v-on:click.prevent="addActivity(activity)">{{activity.niceName}}</a>
+                        </li>
+                      </ul>
+                    </div>
                   </div><!-- /btn-group -->
                 </div>
               </div>


### PR DESCRIPTION
No issue to link it too, but this PR fixes a bug caused by the dependencies updates, which caused weird behaviour in the CSS of the dropdowns for keywords and activities. An update to bootstrap was the culprit, but merging this will make the dropdowns work as before