### PR TITLE
Updated build and deploy process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ pnpm-debug.log*
 *.sw?
 
 /coverage
+data-dot-food-editor.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # data-dot-food-editor change history
 
+## 1.2.0 - 2020-11-17 (Ian)
+
+- Created a new build process to deploy the app via an S3 bucket
+- Rewrite of the README
 
 ## 1.1.5 - 2020-10-30 (Bogdan)
 
@@ -16,7 +20,7 @@
 
 - Added a loading message on the reports page to indicate to the user that the
   pie chart is loading, and some small visual changes
-  
+
 ## 1.1.2 - 2020-10-21 (Bogdan)
 
 - Added validation of the login form inputs

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ more elements, which are subsets of the dataset by some theme (eg. data from a
 certain period of time). The app uses [VueJS](https://vuejs.org) as the main
 framework and was created via [Vue CLI](https://cli.vuejs.org/).
 
+## Developer notes
+
+To install and build the app locally:
+
+```shell
+git clone git@github.com:FoodStandardsAgency/data-dot-food-editor.git
+yarn install
+```
+
 If the app is running in production mode, it will need a local API with the following:
 
 - `/catalog/editor/` as a base endpoint for requests such as datasets, elements,
@@ -15,35 +24,66 @@ If the app is running in production mode, it will need a local API with the foll
 - `/catalog-editor/static/api/Datatypes.json` as an endpoint for datatypes
 
 If the app is running in development mode, all requests to the API will be
-proxied to `https://fsa-dev-catalog-editor.epimorphics.net`, which is the dev server.
+proxied to the [dev server](https://fsa-dev-catalog-editor.epimorphics.net).
+The proxy configuration is managed by `vue.config.js`.
 
-Currently, tests may or may not work. They need a complete rewrite, using
-updated dependencies.
-
-## Project setup
-
-```shell
-yarn install
-```
-
-### Compiles and hot-reloads for development
+To compile and serve the app locally, with and hot-reloads for development:
 
 ```shell
 yarn serve
 ```
 
-### Compiles and minifies for production
+### Testing and linting
+
+Unit tests are written in Jest. We need to increase test coverage.
 
 ```shell
-yarn build
+yarn test:unit
 ```
 
-### Lints and fixes files
+Linting is by eslint using Standard-JS configuration:
 
 ```shell
 yarn lint
 ```
 
-### Customize configuration
+### Issues
 
-See [Configuration Reference](https://cli.vuejs.org/config/).
+Issues for this editor are maintained on the coordinating repo for all data.food
+activities:
+[github.com/FoodStandardsAgency/data-dot-food/issues](https://github.com/FoodStandardsAgency/data-dot-food/issues).
+
+Issues **should** be referenced from commits using the full Github linking syntax:
+
+```text
+FoodStandardsAgency/data-dot-food#issue-number
+```
+
+e.g:
+
+```text
+FoodStandardsAgency/data-dot-food#42
+```
+
+
+### Releases
+
+For each release, ensure you:
+
+- increment the version in `package.json` according to semver principles, and
+- update the [CHANGELOG](CHANGELOG.md) to record the changes
+
+### Deployment
+
+The app is deployed by building the production deployment artefact
+(`data-dot-food-editor.tgz`), pushing that to an S3 bucket corresponding
+to the desired deployment environment (`dev`, `staging`, `production`)
+and then initiating a DMS configuration update via the
+[DMS control panel](https://fsa-controller.epimorphics.net/). Apart
+from the final DMS step, all of the preceding build steps are scripted:
+
+```shell
+yarn deploy:dev
+yarn deploy:staging
+yarn deploy:production
+```

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This script builds a data.food editor deployment and pushes it to
+# an S3 bucket as either dev, staging, or production
+
+DEV_ENV=dev
+STAGING_ENV=staging
+PROD_ENV=production
+
+TARGET=${TARGET:-$DEV_ENV}
+DIST_FILE=data-dot-food-editor.tgz
+
+echo "${DEV_ENV} ${STAGING_ENV} ${PROD_ENV}" | grep -w -q ${TARGET}
+if [ $? -ne 0 ]; then
+  echo "${TARGET} is not a recognised deployment target"
+  exit 1
+fi
+
+echo "Deploying data.food editor to ${TARGET} environment"
+
+rm -rf dist/*
+NODE_ENV=production PUBLIC_PATH=. yarn build
+
+if [ $? -ne 0 ]; then
+  echo "Build step failed. Please check the output and try again"
+  exit 1
+fi
+
+tar  -C dist -czf ${DIST_FILE} .
+
+echo Distribution archive created. Copying to S3.
+
+AWS_PROFILE=${AWS_PROFILE:-fsa}
+
+aws --profile ${AWS_PROFILE} s3 cp ${DIST_FILE} \
+  s3://fsa-dms-deploy/software/data-dot-food/${TARGET}/${DIST_FILE}
+
+if [ $? -ne 0 ]; then
+  echo "AWS S3 copy step failed. Please check your AWS credentials and try again"
+  exit 1
+else
+  echo "Done."
+fi

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -26,6 +26,9 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# Copy additional files
+cp public/htaccess dist/.htaccess
+
 tar  -C dist -czf ${DIST_FILE} .
 
 echo Distribution archive created. Copying to S3.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "data-dot-food-editor",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit --coverage --collectCoverageFrom='src/**/*.{js,vue}'",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "deploy:dev": "bin/deploy.sh",
+    "deploy:staging": "TARGET=staging bin/deploy.sh",
+    "deploy:production": "TARGET=production bin/deploy.sh"
   },
   "dependencies": {
     "bootstrap": "^4.5.2",

--- a/public/htaccess
+++ b/public/htaccess
@@ -1,0 +1,8 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteBase /catalog-editor/
+    RewriteRule ^index\.html$ - [L]
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule . index.html [L]
+</IfModule>

--- a/vue.config.js
+++ b/vue.config.js
@@ -18,7 +18,7 @@ module.exports = {
       title: 'Dataset Editor'
     }
   },
+  publicPath: process.env.PUBLIC_PATH || '',
   configureWebpack: {
-    // All webpack related configs go here
   }
 }


### PR DESCRIPTION
The old build and deploy process committed the built artefacts into Git.
We do not want to continue doing so. The new process creates the app as
`.tgz` file containing the `dist` outputs, and copies that to S3.

Also took a pass over the README to bring it up to date.
